### PR TITLE
Fix: unbond full batch amount

### DIFF
--- a/crates/core/vault.rs
+++ b/crates/core/vault.rs
@@ -795,7 +795,7 @@ impl<'a> Vault for VaultImpl<'a> {
                         epoch,
                     })
                     .add_cmd(StrategyCmd::Unbond {
-                        value: DepositValue(unbond_value),
+                        value: DepositValue(total_unbond_value),
                     });
             }
 


### PR DESCRIPTION
Fix a bug where only the amount unbonded by the last entrant in a batch was used in the unbond command to the strategy.